### PR TITLE
Fix issues #7 docs: update README with GitHub Pages link and custom domain note

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ Each page includes a navigation bar so visitors can easily explore your site. Yo
 
 ---
 
+## Live Deployment
+
+This project is deployed using **GitHub Pages**.  
+🔗 You can view the live site here: [https://ambarmishra973.github.io/personal-portfolio-Lynn-Wahito/](https://ambarmishra973.github.io/personal-portfolio-Lynn-Wahito/)
+
+*Note: No custom domain has been provided for this project. If applicable, please share the domain details and I will be happy to configure it.*
+
+---
+
 ## How to Use
 1. Clone this repository to your local machine.  
 2. Familiarize yourself with the file structure and individual page contents.  


### PR DESCRIPTION
### Summary
This PR Fixes #7 by:
- Adding the GitHub Pages live demo link for the portfolio website.
- Including a note about the custom domain (currently not provided, but added a placeholder note for future use).

### Notes
- The site is successfully deployed at: https://ambarmishra973.github.io/personal-portfolio-Lynn-Wahito/
- No custom domain was specified, so only a placeholder note was added.

### Checklist
- [x] Updated README.md
- [x] Added deployment information
- [x] Mentioned custom domain


<img width="1366" height="768" alt="Screenshot (4)" src="https://github.com/user-attachments/assets/882e9bdc-21e4-49a9-b479-af5006de0c02" />

